### PR TITLE
fix: be more careful with special characters in passwords

### DIFF
--- a/src/main/java/com/sdase/k8s/operator/mongodb/controller/tasks/util/PasswordUtil.java
+++ b/src/main/java/com/sdase/k8s/operator/mongodb/controller/tasks/util/PasswordUtil.java
@@ -10,7 +10,7 @@ public class PasswordUtil {
   private static final String UPPER_CASE = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
   private static final String LOWER_CASE = "abcdefghijklmnopqrstuvwxyz";
   private static final String DIGITS = "0123456789";
-  private static final String SPECIAL_CHARS = "~`!#^&*()-_=+[{]}\\|;'\",<.>?";
+  private static final String SPECIAL_CHARS = "-_,.";
   private static final char[] CHARS =
       (UPPER_CASE + LOWER_CASE + DIGITS + SPECIAL_CHARS).toCharArray();
 

--- a/src/test/java/com/sdase/k8s/operator/mongodb/controller/tasks/util/PasswordUtilTest.java
+++ b/src/test/java/com/sdase/k8s/operator/mongodb/controller/tasks/util/PasswordUtilTest.java
@@ -35,7 +35,7 @@ class PasswordUtilTest {
   void shouldAlwaysHaveSpecialCharacters() {
     var actual = PasswordUtil.createPassword();
     assertThat(actual.toCharArray())
-        .containsAnyOf("~`!@#$%^&*()-_=+[{]}\\|;:'\",<.>/?".toCharArray());
+        .containsAnyOf("-_,.".toCharArray());
   }
 
   @RepeatedTest(1000)


### PR DESCRIPTION
We already realized, that Mongoku has problems with passwords generated here. That may be because they are not well URL encoded or due to Environment variable magic in Kubernetes or the OS of the container. However, we should ensure that these passwords work.