### PR TITLE
fix: handle Ok result from DocumentDB correctly

### DIFF
--- a/src/main/java/com/sdase/k8s/operator/mongodb/db/manager/MongoDbService.java
+++ b/src/main/java/com/sdase/k8s/operator/mongodb/db/manager/MongoDbService.java
@@ -152,6 +152,13 @@ public class MongoDbService {
   }
 
   private boolean isOk(Document response) {
-    return Double.compare(response.get("ok", Double.class), 1.0d) == 0;
+    var okValue = response.get("ok", Object.class);
+    if (okValue instanceof Double) {
+      return Double.compare((Double) okValue, 1.0D) == 0;
+    } else if (okValue instanceof Integer) {
+      return (Integer) okValue == 1;
+    } else {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
When trying out with AWS DocumentDB, the log showed this exception:

```
[EventHandler-mongodbcontroller] ERROR com.sdase.k8s.operator.mongodb.db.manager.MongoDbService - createDatabaseWithUser: mongodb-operator_mongodb-operator-example@mongodb-operator_mongodb-operator-ex
ample: failed
java.lang.ClassCastException: Cannot cast java.lang.Integer to java.lang.Double
        at java.base/java.lang.Class.cast(Unknown Source)
        at org.bson.Document.get(Document.java:145)
        at com.sdase.k8s.operator.mongodb.db.manager.MongoDbService.isOk(MongoDbService.java:155)
        at com.sdase.k8s.operator.mongodb.db.manager.MongoDbService.createUser(MongoDbService.java:149)
        at com.sdase.k8s.operator.mongodb.db.manager.MongoDbService.createDatabaseWithUser(MongoDbService.java:112)
        at com.sdase.k8s.operator.mongodb.controller.MongoDbController.createOrUpdateResource(MongoDbController.java:68)
        at com.sdase.k8s.operator.mongodb.controller.MongoDbController.createOrUpdateResource(MongoDbController.java:14)
        at io.javaoperatorsdk.operator.processing.EventDispatcher.handleCreateOrUpdate(EventDispatcher.java:125)
        at io.javaoperatorsdk.operator.processing.EventDispatcher.handleDispatch(EventDispatcher.java:91)
        at io.javaoperatorsdk.operator.processing.EventDispatcher.handleExecution(EventDispatcher.java:49)
        at io.javaoperatorsdk.operator.processing.ExecutionConsumer.run(ExecutionConsumer.java:25)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
        at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
        at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
        at java.base/java.lang.Thread.run(Unknown Source)
[EventHandler-mongodbcontroller] ERROR io.javaoperatorsdk.operator.processing.EventDispatcher - Error during event processing ExecutionScope{events=[CustomResourceEvent{action=MODIFIED, resource=[ nam
e=mongodb-operator-example, kind=MongoDb, apiVersion=persistence.sda-se.com/v1beta1 ,resourceVersion=21401496, markedForDeletion: false ]}], customResource uid: 2a4c88b2-131b-4276-b704-04eaeeb564a4, v
ersion: 21401496} failed.
```