### PR TITLE
fix: avoid generating password with special character at the beginning

### DIFF
--- a/src/main/java/com/sdase/k8s/operator/mongodb/controller/tasks/util/PasswordUtil.java
+++ b/src/main/java/com/sdase/k8s/operator/mongodb/controller/tasks/util/PasswordUtil.java
@@ -3,7 +3,7 @@ package com.sdase.k8s.operator.mongodb.controller.tasks.util;
 import java.security.SecureRandom;
 import org.apache.commons.lang3.RandomStringUtils;
 
-public class PasswordUtil {
+public final class PasswordUtil {
 
   private static final int PASSWORD_LENGTH = 60;
   private static final SecureRandom SECURE_RANDOM = new SecureRandom();
@@ -35,6 +35,6 @@ public class PasswordUtil {
     return password.chars().anyMatch(c1 -> UPPER_CASE.chars().anyMatch(c2 -> c2 == c1))
         && password.chars().anyMatch(c1 -> LOWER_CASE.chars().anyMatch(c2 -> c2 == c1))
         && password.chars().anyMatch(c1 -> DIGITS.chars().anyMatch(c2 -> c2 == c1))
-        && password.chars().anyMatch(c1 -> SPECIAL_CHARS.chars().anyMatch(c2 -> c2 == c1));
+        && password.chars().skip(1).anyMatch(c1 -> SPECIAL_CHARS.chars().anyMatch(c2 -> c2 == c1));
   }
 }

--- a/src/test/java/com/sdase/k8s/operator/mongodb/controller/tasks/util/PasswordUtilTest.java
+++ b/src/test/java/com/sdase/k8s/operator/mongodb/controller/tasks/util/PasswordUtilTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.RepeatedTest;
 
 class PasswordUtilTest {
 
+  private static final String SPECIAL_CHARS = "-_,.";
+
   @RepeatedTest(1000)
   void shouldAlwaysHaveUpperCaseLetters() {
     var actual = PasswordUtil.createPassword();
@@ -29,7 +31,13 @@ class PasswordUtilTest {
   @RepeatedTest(1000)
   void shouldAlwaysHaveSpecialCharacters() {
     var actual = PasswordUtil.createPassword();
-    assertThat(actual.toCharArray()).containsAnyOf("-_,.".toCharArray());
+    assertThat(actual.toCharArray()).containsAnyOf(SPECIAL_CHARS.toCharArray());
+  }
+
+  @RepeatedTest(1000)
+  void shouldNeverContainSpecialCharacterAtTheBeginning() {
+    var actual = PasswordUtil.createPassword();
+    assertThat(Character.toString(actual.charAt(0))).doesNotContain(SPECIAL_CHARS);
   }
 
   @RepeatedTest(1000)


### PR DESCRIPTION
reason: that causes yaml parser to fail on dropwizard service startup with exception:
```
Exception while parsing a block node
 in 'reader', line 69, column 13:
      password: ,x9NgyzBIxLJfucrpc3JnCyNH933gFpB ...
expected the node content, but found ','
 in 'reader', line 69, column 13:
      password: ,x9NgyzBIxLJfucrpc3JnCyNH933gFpB ...
at org.yaml.snakeyaml.parser.ParserImpl.parseNode(ParserImpl.java:540)
```