### PR TITLE
Create health check scripts for ArgoCD

### DIFF
--- a/.github/workflows/health-argocd-local-ci.yml
+++ b/.github/workflows/health-argocd-local-ci.yml
@@ -1,0 +1,24 @@
+name: Health ArgoCD Local
+
+# This workflow tests the Lua scripts for MongoDb health status in ArgoCD
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v2.4.0
+
+      - uses: leafo/gh-actions-lua@v10
+      - uses: leafo/gh-actions-luarocks@v4
+      - name: Test
+        run: |
+          luarocks --server=http://rocks.moonscript.org install lyaml
+          lua health/argocd/persistence.sda-se.com/MongoDb/health_test.lua

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Pleaser refer to the [deployment documentation](docs/deployment.md) for installi
 in a Kubernetes Cluster or to the [usage documentation](docs/usage) to see how to request a database
 for a workload.
 The full documentation is available on [GitHub Pages](https://sda-se.github.io/mongodb-operator/).
+If ArgoCD is used for deployment, the [provided custom health check](./health/argocd/README.md) can
+be used to include `MongoDb` resource in the application health.
 
 The image is hosted at [quay.io/sdase/mongodb-operator](https://quay.io/repository/sdase/mongodb-operator).
 

--- a/docs/argocd.md
+++ b/docs/argocd.md
@@ -1,0 +1,12 @@
+# ArgoCD
+
+If applications that use `MongoDb` resources are [deployed](deployment.md) with [ArgoCD](https://argo-cd.readthedocs.io/),
+no information about success is available in the ArgoCD UI.
+The application seems healthy even when no database can be created.
+
+To enhance visibility of custom resources, ArgoCD has a feature to provide
+[health checks](https://argo-cd.readthedocs.io/en/stable/operator-manual/health/#resource-health)
+to consider the custom resource like `MongoDb` for the overall health of an application.
+
+The specific [Lua health script](https://github.com/SDA-SE/mongodb-operator/blob/master/health/argocd/persistence.sda-se.com/MongoDb/health.lua)
+for the `MongoDb` custom resource can be added to the `argocd-cm` ConfigMap.

--- a/health/argocd/README.md
+++ b/health/argocd/README.md
@@ -1,0 +1,39 @@
+# Health Checks for ArgoCD
+
+This directory contains the root source of an ArgoCD health check for `MongoDb` resources.
+It is written in _Lua_ as [required by ArgoCD](https://argo-cd.readthedocs.io/en/stable/operator-manual/health/#resource-health).
+The setup follows the [conventions of contribution](https://argo-cd.readthedocs.io/en/stable/operator-manual/health/#way-2-contribute-a-custom-health-check)
+but adds a Lua script for easier local testing.
+
+[`health.lua`](./persistence.sda-se.com/MongoDb/health.lua) can be used in the `argocd-cm`
+ConfigMap.
+
+## Development and Testing
+
+### Preparation
+
+```console
+$ brew install lua
+==> Fetching lua
+==> Caveats
+You may also want luarocks:
+  brew install luarocks
+==> Summary
+🍺  /opt/homebrew/Cellar/lua/5.4.6: 29 files, 788.1KB
+==> Running `brew cleanup lua`...
+$ brew install luarocks
+==> Fetching luarocks
+==> Summary
+🍺  /opt/homebrew/Cellar/luarocks/3.9.2: 103 files, 728.3KB
+==> Running `brew cleanup luarocks`...
+$ luarocks --server=http://rocks.moonscript.org install lyaml
+lyaml 6.2.8-1 is now installed in /opt/homebrew (license: MIT/X11)
+```
+
+### Executing tests
+
+In base dir of MongoDB Operator repository:
+
+```console
+$ lua health/argocd/persistence.sda-se.com/MongoDb/health_test.lua
+```

--- a/health/argocd/persistence.sda-se.com/MongoDb/health.lua
+++ b/health/argocd/persistence.sda-se.com/MongoDb/health.lua
@@ -1,0 +1,23 @@
+health_status={}
+if obj.status ~= nil then
+  if obj.status.conditions ~= nil and #(obj.status.conditions) > 0 then
+    for i, condition in ipairs(obj.status.conditions) do
+      if condition.status ~= "True" then
+        health_status.status = "Degraded"
+        health_status.message = condition.message
+        return health_status
+      end
+    end
+    if #(obj.status.conditions) < 3 then
+      health_status.status = "Degraded"
+      health_status.message = "Missing conditions."
+      return health_status
+    end
+    health_status.status = "Healthy"
+    health_status.message = "Database and secret created."
+    return health_status
+  end
+end
+health_status.status = "Progressing"
+health_status.message = "Waiting for database creation."
+return health_status

--- a/health/argocd/persistence.sda-se.com/MongoDb/health_test.lua
+++ b/health/argocd/persistence.sda-se.com/MongoDb/health_test.lua
@@ -1,0 +1,31 @@
+local io = require("io")
+local yml = require "lyaml"
+
+-- relative to repo root
+local basePath = "./health/argocd/persistence.sda-se.com/MongoDb/"
+
+function readAll(file)
+  local f = assert(io.open(file, "rb"))
+  local content = f:read("*all")
+  f:close()
+  return content
+end
+
+local testsSource = readAll(basePath .. "health_test.yaml")
+
+local tests = yml.load(testsSource)
+print(tests)
+
+for i, test in ipairs(tests.tests) do
+  print("Testing: " .. test.inputPath)
+  local given = readAll(basePath .. test.inputPath)
+  obj = yml.load(given)
+  local result = dofile(basePath .. "health.lua")
+  assert(result.status ~= nil, "Actual status is nil")
+  assert ( result.status == test.healthStatus.status, "Expected status " .. test.healthStatus.status .. " does not match actual status " .. result.status)
+  print("  Status asserted: " .. result.status)
+  assert(result.message ~= nil, "Actual message is nil")
+  assert ( result.message == test.healthStatus.message, "Expected message '" .. test.healthStatus.message .. "' does not match actual message '" .. result.message .. "'")
+  print("  Message asserted: " .. result.message)
+end
+

--- a/health/argocd/persistence.sda-se.com/MongoDb/health_test.yaml
+++ b/health/argocd/persistence.sda-se.com/MongoDb/health_test.yaml
@@ -1,0 +1,31 @@
+tests:
+  - healthStatus:
+      status: Progressing
+      message: Waiting for database creation.
+    inputPath: testdata/progressing_noStatus.yaml
+  - healthStatus:
+      status: Progressing
+      message: Waiting for database creation.
+    inputPath: testdata/progressing_emptyConditions.yaml
+  - healthStatus:
+      status: Degraded
+      message: Missing conditions.
+    inputPath: testdata/degraded_twoConditionsTrue.yaml
+  - healthStatus:
+      status: Degraded
+      message: >-
+        Unable to create valid name with less than 64 characters from namespace my-namespace and
+        name my-database-has-very-very-long-name-that-is-actually-too-long
+    inputPath: testdata/degraded_username.yaml
+  - healthStatus:
+      status: Degraded
+      message: Database creation failed
+    inputPath: testdata/degraded_database.yaml
+  - healthStatus:
+      status: Degraded
+      message: Secret creation failed
+    inputPath: testdata/degraded_secret.yaml
+  - healthStatus:
+      status: Healthy
+      message: Database and secret created.
+    inputPath: testdata/healthy.yaml

--- a/health/argocd/persistence.sda-se.com/MongoDb/testdata/degraded_database.yaml
+++ b/health/argocd/persistence.sda-se.com/MongoDb/testdata/degraded_database.yaml
@@ -1,0 +1,34 @@
+apiVersion: persistence.sda-se.com/v1beta1
+kind: MongoDb
+metadata:
+  creationTimestamp: '2023-03-17T09:53:26Z'
+  finalizers:
+    - mongodbs.persistence.sda-se.com/finalizer
+  generation: 1
+  name: my-database
+  namespace: my-namespace
+  uid: 6d8a3e01-88e5-44c6-9701-bbaf00abed5b
+spec:
+  database:
+    pruneAfterDelete: true
+status:
+  attempts: 1
+  conditions:
+    - lastTransitionTime: '2023-03-17T09:53:26.270552Z'
+      message: Username my-namespace_my-database created.
+      observedGeneration: 1
+      reason: CreateOrUpdate
+      status: 'True'
+      type: CreateUsername
+    - lastTransitionTime: '2023-03-17T09:53:26.270607Z'
+      message: Database creation failed
+      observedGeneration: 1
+      reason: CreateOrUpdate
+      status: 'False'
+      type: CreateDatabase
+    - lastTransitionTime: '2023-03-17T09:53:26.270625Z'
+      message: Secret created
+      observedGeneration: 1
+      reason: CreateOrUpdate
+      status: 'Unknown'
+      type: CreateSecret

--- a/health/argocd/persistence.sda-se.com/MongoDb/testdata/degraded_secret.yaml
+++ b/health/argocd/persistence.sda-se.com/MongoDb/testdata/degraded_secret.yaml
@@ -1,0 +1,34 @@
+apiVersion: persistence.sda-se.com/v1beta1
+kind: MongoDb
+metadata:
+  creationTimestamp: '2023-03-17T09:53:26Z'
+  finalizers:
+    - mongodbs.persistence.sda-se.com/finalizer
+  generation: 1
+  name: my-database
+  namespace: my-namespace
+  uid: 6d8a3e01-88e5-44c6-9701-bbaf00abed5b
+spec:
+  database:
+    pruneAfterDelete: true
+status:
+  attempts: 1
+  conditions:
+    - lastTransitionTime: '2023-03-17T09:53:26.270552Z'
+      message: Username my-namespace_my-database created.
+      observedGeneration: 1
+      reason: CreateOrUpdate
+      status: 'True'
+      type: CreateUsername
+    - lastTransitionTime: '2023-03-17T09:53:26.270607Z'
+      message: Database created
+      observedGeneration: 1
+      reason: CreateOrUpdate
+      status: 'True'
+      type: CreateDatabase
+    - lastTransitionTime: '2023-03-17T09:53:26.270625Z'
+      message: Secret creation failed
+      observedGeneration: 1
+      reason: CreateOrUpdate
+      status: 'False'
+      type: CreateSecret

--- a/health/argocd/persistence.sda-se.com/MongoDb/testdata/degraded_twoConditionsTrue.yaml
+++ b/health/argocd/persistence.sda-se.com/MongoDb/testdata/degraded_twoConditionsTrue.yaml
@@ -1,0 +1,28 @@
+apiVersion: persistence.sda-se.com/v1beta1
+kind: MongoDb
+metadata:
+  creationTimestamp: '2023-03-17T09:53:26Z'
+  finalizers:
+    - mongodbs.persistence.sda-se.com/finalizer
+  generation: 1
+  name: my-database
+  namespace: my-namespace
+  uid: 6d8a3e01-88e5-44c6-9701-bbaf00abed5b
+spec:
+  database:
+    pruneAfterDelete: true
+status:
+  attempts: 1
+  conditions:
+    - lastTransitionTime: '2023-03-17T09:53:26.270552Z'
+      message: Username my-namespace_my-database created.
+      observedGeneration: 1
+      reason: CreateOrUpdate
+      status: 'True'
+      type: CreateUsername
+    - lastTransitionTime: '2023-03-17T09:53:26.270607Z'
+      message: Database created
+      observedGeneration: 1
+      reason: CreateOrUpdate
+      status: 'True'
+      type: CreateDatabase

--- a/health/argocd/persistence.sda-se.com/MongoDb/testdata/degraded_username.yaml
+++ b/health/argocd/persistence.sda-se.com/MongoDb/testdata/degraded_username.yaml
@@ -1,0 +1,36 @@
+apiVersion: persistence.sda-se.com/v1beta1
+kind: MongoDb
+metadata:
+  creationTimestamp: '2023-03-17T09:53:26Z'
+  finalizers:
+    - mongodbs.persistence.sda-se.com/finalizer
+  generation: 1
+  name: my-database-has-very-very-long-name-that-is-actually-too-long
+  namespace: my-namespace
+  uid: 6d8a3e01-88e5-44c6-9701-bbaf00abed5b
+spec:
+  database:
+    pruneAfterDelete: true
+status:
+  attempts: 1
+  conditions:
+    - lastTransitionTime: '2023-03-17T09:53:26.270552Z'
+      message: >-
+        Unable to create valid name with less than 64 characters from namespace my-namespace and
+        name my-database-has-very-very-long-name-that-is-actually-too-long
+      observedGeneration: 1
+      reason: CreateOrUpdate
+      status: 'False'
+      type: CreateUsername
+    - lastTransitionTime: '2023-03-17T09:53:26.270607Z'
+      message: Database created
+      observedGeneration: 1
+      reason: CreateOrUpdate
+      status: 'Unknown'
+      type: CreateDatabase
+    - lastTransitionTime: '2023-03-17T09:53:26.270625Z'
+      message: Secret created
+      observedGeneration: 1
+      reason: CreateOrUpdate
+      status: 'Unknown'
+      type: CreateSecret

--- a/health/argocd/persistence.sda-se.com/MongoDb/testdata/healthy.yaml
+++ b/health/argocd/persistence.sda-se.com/MongoDb/testdata/healthy.yaml
@@ -1,0 +1,34 @@
+apiVersion: persistence.sda-se.com/v1beta1
+kind: MongoDb
+metadata:
+  creationTimestamp: '2023-03-17T09:53:26Z'
+  finalizers:
+    - mongodbs.persistence.sda-se.com/finalizer
+  generation: 1
+  name: my-database
+  namespace: my-namespace
+  uid: 6d8a3e01-88e5-44c6-9701-bbaf00abed5b
+spec:
+  database:
+    pruneAfterDelete: true
+status:
+  attempts: 1
+  conditions:
+    - lastTransitionTime: '2023-03-17T09:53:26.270552Z'
+      message: Username my-namespace_my-database created.
+      observedGeneration: 1
+      reason: CreateOrUpdate
+      status: 'True'
+      type: CreateUsername
+    - lastTransitionTime: '2023-03-17T09:53:26.270607Z'
+      message: Database created
+      observedGeneration: 1
+      reason: CreateOrUpdate
+      status: 'True'
+      type: CreateDatabase
+    - lastTransitionTime: '2023-03-17T09:53:26.270625Z'
+      message: Secret created
+      observedGeneration: 1
+      reason: CreateOrUpdate
+      status: 'True'
+      type: CreateSecret

--- a/health/argocd/persistence.sda-se.com/MongoDb/testdata/progressing_emptyConditions.yaml
+++ b/health/argocd/persistence.sda-se.com/MongoDb/testdata/progressing_emptyConditions.yaml
@@ -1,0 +1,16 @@
+apiVersion: persistence.sda-se.com/v1beta1
+kind: MongoDb
+metadata:
+  creationTimestamp: '2023-03-17T09:53:26Z'
+  finalizers:
+    - mongodbs.persistence.sda-se.com/finalizer
+  generation: 1
+  name: my-database
+  namespace: my-namespace
+  uid: 6d8a3e01-88e5-44c6-9701-bbaf00abed5b
+spec:
+  database:
+    pruneAfterDelete: true
+status:
+  attempts: 1
+  conditions: []

--- a/health/argocd/persistence.sda-se.com/MongoDb/testdata/progressing_noStatus.yaml
+++ b/health/argocd/persistence.sda-se.com/MongoDb/testdata/progressing_noStatus.yaml
@@ -1,0 +1,13 @@
+apiVersion: persistence.sda-se.com/v1beta1
+kind: MongoDb
+metadata:
+  creationTimestamp: '2023-03-17T09:53:26Z'
+  finalizers:
+    - mongodbs.persistence.sda-se.com/finalizer
+  generation: 1
+  name: my-database
+  namespace: my-namespace
+  uid: 6d8a3e01-88e5-44c6-9701-bbaf00abed5b
+spec:
+  database:
+    pruneAfterDelete: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ site_name: 'MongoDB Operator'
 nav:
   - MongoDB Operator: index.md
   - Deployment: deployment.md
+  - ArgoCD: argocd.md
   - Usage: usage.md
   - How the MongoDB Operator works: process.md
 


### PR DESCRIPTION
- Local Workflow for testing shows failure on bad conditions in [this temporary run](https://github.com/SDA-SE/mongodb-operator/actions/runs/5208905467/jobs/9398064273?pr=285).
- There is an official introduction about [the Health setup in ArgoCD](https://argo-cd.readthedocs.io/en/stable/operator-manual/health/#way-2-contribute-a-custom-health-check) and [a structure to follow](https://github.com/argoproj/argo-cd/tree/master/resource_customizations) where this setup is derived from.