### PR TITLE
fix(logging): reset default log level to info

### DIFF
--- a/src/main/java/com/sdase/k8s/operator/mongodb/logging/LogConfigurer.java
+++ b/src/main/java/com/sdase/k8s/operator/mongodb/logging/LogConfigurer.java
@@ -1,5 +1,6 @@
 package com.sdase.k8s.operator.mongodb.logging;
 
+import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.layout.TTLLLayout;
 import ch.qos.logback.classic.spi.ILoggingEvent;
@@ -26,6 +27,7 @@ public class LogConfigurer {
       } else {
         rootLogger.addAppender(defaultAppender(loggerContext));
       }
+      rootLogger.setLevel(Level.INFO);
     }
   }
 

--- a/src/test/java/com/sdase/k8s/operator/mongodb/LoggingTest.java
+++ b/src/test/java/com/sdase/k8s/operator/mongodb/LoggingTest.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sdase.k8s.operator.mongodb.logging.LogConfigurer;
 import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.StdIo;
@@ -137,6 +138,46 @@ class LoggingTest {
                           \tat app//com.sdase.k8s.operator.mongodb.LoggingTest.shouldLogExceptionAsJson(LoggingTest.java:100)
                           """);
             });
+  }
+
+  @Test
+  @StdIo
+  void shouldLogInfoAndAboveJson(StdOut out) {
+    LogConfigurer.configure(true);
+    LOG.trace("trace shouldLogInfoAndAbove");
+    LOG.debug("debug shouldLogInfoAndAbove");
+    LOG.info("info shouldLogInfoAndAbove");
+    LOG.warn("warn shouldLogInfoAndAbove");
+    LOG.error("error shouldLogInfoAndAbove");
+    await()
+        .untilAsserted(
+            () ->
+                assertThat(StringUtils.join(out.capturedLines(), "\n"))
+                    .contains("error shouldLogInfoAndAbove")
+                    .contains("warn shouldLogInfoAndAbove")
+                    .contains("info shouldLogInfoAndAbove")
+                    .doesNotContain("debug shouldLogInfoAndAbove")
+                    .doesNotContain("trace shouldLogInfoAndAbove"));
+  }
+
+  @Test
+  @StdIo
+  void shouldLogInfoAndAboveRegular(StdOut out) {
+    LogConfigurer.configure(false);
+    LOG.trace("trace shouldLogInfoAndAbove");
+    LOG.debug("debug shouldLogInfoAndAbove");
+    LOG.info("info shouldLogInfoAndAbove");
+    LOG.warn("warn shouldLogInfoAndAbove");
+    LOG.error("error shouldLogInfoAndAbove");
+    await()
+        .untilAsserted(
+            () ->
+                assertThat(StringUtils.join(out.capturedLines(), "\n"))
+                    .contains("error shouldLogInfoAndAbove")
+                    .contains("warn shouldLogInfoAndAbove")
+                    .contains("info shouldLogInfoAndAbove")
+                    .doesNotContain("debug shouldLogInfoAndAbove")
+                    .doesNotContain("trace shouldLogInfoAndAbove"));
   }
 
   static class TestException extends RuntimeException {


### PR DESCRIPTION
This is a quickfix to avoid debug messages logged by default in production environments. In a follow-up, we may also make logging more configurable.

/closes #292 partially