### PR TITLE
fix(release): change order of git and exec plugin

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -4,8 +4,8 @@ debug: true
 plugins:
   - "@semantic-release/commit-analyzer"
   - "@semantic-release/release-notes-generator"
+  - ["@semantic-release/exec", { "prepareCmd": "./release-prepare.sh \"${nextRelease.version}\"" }]
   - "@semantic-release/git"
   - "@semantic-release/github"
-  - ["@semantic-release/exec", { "prepareCmd": "./release-prepare.sh \"${nextRelease.version}\"" }]
 branches:
   - name: 'master'


### PR DESCRIPTION
Seems like [the order is important](https://github.com/semantic-release/semantic-release/issues/902#issuecomment-413904819) and the plugins do not have inherent dependencies.

The [logs](https://github.com/SDA-SE/mongodb-operator/actions/runs/5275902886/jobs/9541967964) also show that `git` is running before `exec`.