### PR TITLE
fix(release): remove skip ci to execute GH pages build

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -14,7 +14,7 @@ plugins:
         "kustomize/overlays/remote-examples/no-namespace/kustomization.yaml",
         "kustomize/release/no-namespace/kustomization.yaml"
       ],
-      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      "message": "chore(release): prepare remote base for version ${nextRelease.version}\n\n${nextRelease.notes}"
     }
   ]
   - "@semantic-release/git"


### PR DESCRIPTION
Unfortunately, we execute more workflows than needed this way. But without having a build for the prepare commit, we do not get the latest documentation that is ready for copy and paste with correct versions for the remote bases.