### PR TITLE
fix(security): bump com.squareup.okio:okio:1.15.0 to 3.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,11 +61,16 @@ dependencies {
   implementation "io.javaoperatorsdk:operator-framework:${operatorFrameworkVersion}", {
     // self managed to avoid conflicts
     exclude group: "org.slf4j"
+    exclude group: 'com.squareup.okio', module: 'okio'
   }
   annotationProcessor "io.javaoperatorsdk:operator-framework:${operatorFrameworkVersion}", {
     // self managed to avoid conflicts
     exclude group: "org.slf4j"
+    // recheck when operator-framework is upgraded
+    exclude group: 'com.squareup.okio', module: 'okio'
   }
+  // upgrade from transitive 1.15.0 in okhttp to fix CVE-2023-3635
+  implementation 'com.squareup.okio:okio:3.4.0'
 
   implementation "org.mongodb:mongodb-driver-sync:${mongoDbDriverVersion}"
 
@@ -117,6 +122,7 @@ dependencies {
     // self managed to avoid conflicts
     exclude group: "org.slf4j"
     exclude group: "junit"
+    exclude group: 'com.squareup.okio', module: 'okio'
   }
   testImplementation "junit:junit:4.13.2"
 }


### PR DESCRIPTION
okio is a transitive dependency of com.squareup.okhttp3:okhttp:3.12.12. This update should fix CVE-2023-3635.

```console
$ ./gradlew resolveAndLockAll --write-locks
Persisted dependency lock state for buildscript of project ':'
Persisted dependency lock state for project ':'

BUILD SUCCESSFUL in 1s
1 actionable task: 1 executed
$ trivy fs -s MEDIUM,HIGH,CRITICAL --scanners vuln .
2023-07-17T14:45:02.311+0200    INFO    Need to update DB
2023-07-17T14:45:02.311+0200    INFO    DB Repository: ghcr.io/aquasecurity/trivy-db
2023-07-17T14:45:02.311+0200    INFO    Downloading DB...
38.41 MiB / 38.41 MiB [------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 8.31 MiB p/s 4.8s
2023-07-17T14:45:08.173+0200    INFO    Vulnerability scanning is enabled
2023-07-17T14:45:08.417+0200    INFO    Number of language-specific files: 2
2023-07-17T14:45:08.417+0200    INFO    Detecting pom vulnerabilities...
2023-07-17T14:45:08.417+0200    INFO    Detecting gradle vulnerabilities...
```
@SDA-SE/bedrock this is a [big major bump of a transitive dependency](https://github.com/square/okio/blob/master/CHANGELOG.md). Any idea how to double check, that this does not break?