### PR TITLE
fix(monitoring): migrate monitoring server from spark-java to Javalin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
 
   implementation enforcedPlatform("com.fasterxml.jackson:jackson-bom:${jacksonVersion}")
   annotationProcessor enforcedPlatform("com.fasterxml.jackson:jackson-bom:${jacksonVersion}")
-  implementation enforcedPlatform('org.eclipse.jetty:jetty-bom:9.4.52.v20230823')
+  implementation enforcedPlatform('org.eclipse.jetty:jetty-bom:11.0.16')
 
   implementation "io.javaoperatorsdk:operator-framework:${operatorFrameworkVersion}", {
     // self managed to avoid conflicts
@@ -78,9 +78,12 @@ dependencies {
   implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
   implementation 'jakarta.el:jakarta.el-api:5.0.1'
   implementation 'org.bouncycastle:bcpkix-jdk18on:1.76'
-  implementation "com.sparkjava:spark-core:2.9.4", {
+  implementation "io.javalin:javalin:5.6.1", {
     // self managed to avoid conflicts
     exclude group: "org.slf4j"
+    // older versions than in okio
+    exclude group: "org.jetbrains", module: "annotations"
+    exclude group: "org.jetbrains.kotlin", module: "kotlin-stdlib-jdk8"
   }
 
   // logging

--- a/src/test/java/com/sdase/k8s/operator/mongodb/MongoDbOperatorTest.java
+++ b/src/test/java/com/sdase/k8s/operator/mongodb/MongoDbOperatorTest.java
@@ -2,6 +2,7 @@ package com.sdase.k8s.operator.mongodb;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.fail;
 import static org.awaitility.Awaitility.await;
 
@@ -28,7 +29,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import spark.Spark;
 import uk.org.webcompere.systemstubs.SystemStubs;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 
@@ -110,7 +110,15 @@ class MongoDbOperatorTest extends AbstractMongoDbTest {
       await().atMost(20, SECONDS).untilAsserted(this::assertReadinessEndpointAvailable);
     } finally {
       testThread.interrupt();
-      Spark.stop();
+      await()
+          .untilAsserted(
+              () ->
+                  assertThatNoException()
+                      .isThrownBy(
+                          () -> {
+                            //noinspection EmptyTryBlock
+                            try (var ignored = new ServerSocket(port)) {}
+                          }));
     }
   }
 

--- a/src/test/java/com/sdase/k8s/operator/mongodb/monitoring/MonitoringServerTest.java
+++ b/src/test/java/com/sdase/k8s/operator/mongodb/monitoring/MonitoringServerTest.java
@@ -27,8 +27,10 @@ class MonitoringServerTest {
 
   @BeforeEach
   void startServer() throws IOException {
-    try (ServerSocket serverSocket = new ServerSocket(0)) {
-      port = serverSocket.getLocalPort();
+    while (monitoringServer == null) {
+      try (ServerSocket serverSocket = new ServerSocket(0)) {
+        port = serverSocket.getLocalPort();
+      }
       monitoringServer = new MonitoringServer(port, List.of(ready::get)).start();
     }
   }
@@ -36,6 +38,8 @@ class MonitoringServerTest {
   @AfterEach
   void stopServer() {
     monitoringServer.stop();
+    monitoringServer = null;
+    port = 0;
   }
 
   @RetryingTest(5)


### PR DESCRIPTION
Backround: Spark Java is not receiving updates since a year and uses an old version of Jetty. Javalin is more active now and follows a similar „no magic“ approach like Spark Java.