### PR TITLE
fix(deps): bump ch.qos.logback:logback-classic from 1.4.13 to 1.4.14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ dependencies {
   // logging
   annotationProcessor "org.slf4j:slf4j-api:${slf4jVersion}"
   implementation "org.slf4j:slf4j-api:${slf4jVersion}"
-  implementation 'ch.qos.logback:logback-classic:1.4.13', {
+  implementation 'ch.qos.logback:logback-classic:1.4.14', {
     exclude group: "org.slf4j", module: "slf4j-api"
   }
   implementation "ch.qos.logback.contrib:logback-json-classic:${logbackContribVersion}", {


### PR DESCRIPTION
manual alternative to https://github.com/SDA-SE/mongodb-operator/pull/384
why does Github not build Dependabot PRs anymore?