### PR TITLE
Custom secret keys are not populated

### DIFF
--- a/kustomize/overlays/test/kustomization.yaml
+++ b/kustomize/overlays/test/kustomization.yaml
@@ -6,4 +6,5 @@ namespace: local-test
 resources:
   - local-test-ns.yaml
   - local-test-db-mongo.yaml
+  - local-test-defaults-db-mongo.yaml
   - local-test-db-with-way-too-long-name-that-exceeds-all-limits-mongo.yaml

--- a/kustomize/overlays/test/local-test-defaults-db-mongo.yaml
+++ b/kustomize/overlays/test/local-test-defaults-db-mongo.yaml
@@ -1,0 +1,5 @@
+apiVersion: persistence.sda-se.com/v1beta1
+kind: MongoDb
+metadata:
+  name: local-test-defaults-db
+spec: {}

--- a/src/main/java/com/sdase/k8s/operator/mongodb/controller/V1SecretBuilder.java
+++ b/src/main/java/com/sdase/k8s/operator/mongodb/controller/V1SecretBuilder.java
@@ -2,6 +2,8 @@ package com.sdase.k8s.operator.mongodb.controller;
 
 import com.sdase.k8s.operator.mongodb.controller.tasks.CreateDatabaseTask;
 import com.sdase.k8s.operator.mongodb.model.v1beta1.MongoDbCustomResource;
+import com.sdase.k8s.operator.mongodb.model.v1beta1.MongoDbSpec;
+import com.sdase.k8s.operator.mongodb.model.v1beta1.SecretSpec;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Secret;
@@ -9,6 +11,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public class V1SecretBuilder {
 
@@ -19,15 +22,18 @@ public class V1SecretBuilder {
     var username = createDatabaseTask.username();
     var password = createDatabaseTask.password();
     var connectionString = createDatabaseTask.connectionString();
+    var secretSpec = Optional.ofNullable(owner.getSpec()).map(MongoDbSpec::getSecret);
     secret.setData(
         Map.of(
-            owner.getSpec().getSecret().getDatabaseKey(),
+            secretSpec.map(SecretSpec::getDatabaseKey).orElse(SecretSpec.DEFAULT_DATABASE_KEY),
             base64(database),
-            owner.getSpec().getSecret().getUsernameKey(),
+            secretSpec.map(SecretSpec::getUsernameKey).orElse(SecretSpec.DEFAULT_USERNAME_KEY),
             base64(username),
-            owner.getSpec().getSecret().getPasswordKey(),
+            secretSpec.map(SecretSpec::getPasswordKey).orElse(SecretSpec.DEFAULT_PASSWORD_KEY),
             base64(password),
-            owner.getSpec().getSecret().getConnectionStringKey(),
+            secretSpec
+                .map(SecretSpec::getConnectionStringKey)
+                .orElse(SecretSpec.DEFAULT_CONNECTION_STRING_KEY),
             base64(connectionString)));
     ObjectMeta secretMetadata = createMetaDataFromOwnerResource(owner);
     secret.setMetadata(secretMetadata);

--- a/src/main/java/com/sdase/k8s/operator/mongodb/controller/tasks/TaskFactory.java
+++ b/src/main/java/com/sdase/k8s/operator/mongodb/controller/tasks/TaskFactory.java
@@ -6,6 +6,7 @@ import com.sdase.k8s.operator.mongodb.controller.tasks.util.NamingUtil;
 import com.sdase.k8s.operator.mongodb.controller.tasks.util.PasswordUtil;
 import com.sdase.k8s.operator.mongodb.model.v1beta1.DatabaseSpec;
 import com.sdase.k8s.operator.mongodb.model.v1beta1.MongoDbCustomResource;
+import com.sdase.k8s.operator.mongodb.model.v1beta1.MongoDbSpec;
 import java.util.Optional;
 import java.util.function.Function;
 import org.apache.commons.lang3.StringUtils;
@@ -45,7 +46,8 @@ public class TaskFactory {
     var username = usernameCreator.apply(mongoDbCustomResource);
     var password = passwordCreator.apply(mongoDbCustomResource);
     var options =
-        Optional.ofNullable(mongoDbCustomResource.getSpec().getDatabase())
+        Optional.ofNullable(mongoDbCustomResource.getSpec())
+            .map(MongoDbSpec::getDatabase)
             .map(DatabaseSpec::getConnectionStringOptions)
             .filter(StringUtils::isNotBlank)
             .orElse(null);
@@ -62,6 +64,9 @@ public class TaskFactory {
         mongoDbCustomResource,
         databaseNameCreator.apply(mongoDbCustomResource),
         usernameCreator.apply(mongoDbCustomResource),
-        mongoDbCustomResource.getSpec().getDatabase().isPruneAfterDelete());
+        Optional.ofNullable(mongoDbCustomResource.getSpec())
+            .map(MongoDbSpec::getDatabase)
+            .map(DatabaseSpec::isPruneAfterDelete)
+            .orElse(false));
   }
 }

--- a/src/main/java/com/sdase/k8s/operator/mongodb/model/v1beta1/MongoDbCustomResource.java
+++ b/src/main/java/com/sdase/k8s/operator/mongodb/model/v1beta1/MongoDbCustomResource.java
@@ -10,10 +10,4 @@ import io.fabric8.kubernetes.model.annotation.Version;
 @Group("persistence.sda-se.com")
 @Kind("MongoDb")
 public class MongoDbCustomResource extends CustomResource<MongoDbSpec, MongoDbStatus>
-    implements Namespaced {
-
-  public MongoDbCustomResource() {
-    super();
-    setSpec(new MongoDbSpec());
-  }
-}
+    implements Namespaced {}

--- a/src/main/java/com/sdase/k8s/operator/mongodb/model/v1beta1/MongoDbSpec.java
+++ b/src/main/java/com/sdase/k8s/operator/mongodb/model/v1beta1/MongoDbSpec.java
@@ -2,9 +2,9 @@ package com.sdase.k8s.operator.mongodb.model.v1beta1;
 
 public class MongoDbSpec {
 
-  private DatabaseSpec database = new DatabaseSpec();
+  private DatabaseSpec database;
 
-  private SecretSpec secret = new SecretSpec();
+  private SecretSpec secret;
 
   public DatabaseSpec getDatabase() {
     return database;

--- a/src/main/java/com/sdase/k8s/operator/mongodb/model/v1beta1/SecretSpec.java
+++ b/src/main/java/com/sdase/k8s/operator/mongodb/model/v1beta1/SecretSpec.java
@@ -2,18 +2,18 @@ package com.sdase.k8s.operator.mongodb.model.v1beta1;
 
 public class SecretSpec {
 
-  private static final String DEFAULT_DATABASE_KEY = "database";
-  private static final String DEFAULT_USERNAME_KEY = "username";
-  private static final String DEFAULT_PASSWORD_KEY = "password";
-  private static final String DEFAULT_CONNECTION_STRING_KEY = "connectionString";
+  public static final String DEFAULT_DATABASE_KEY = "database";
+  public static final String DEFAULT_USERNAME_KEY = "username";
+  public static final String DEFAULT_PASSWORD_KEY = "password";
+  public static final String DEFAULT_CONNECTION_STRING_KEY = "connectionString";
 
-  private String databaseKey = DEFAULT_DATABASE_KEY;
+  private String databaseKey;
 
-  private String usernameKey = DEFAULT_USERNAME_KEY;
+  private String usernameKey;
 
-  private String passwordKey = DEFAULT_PASSWORD_KEY;
+  private String passwordKey;
 
-  private String connectionStringKey = DEFAULT_CONNECTION_STRING_KEY;
+  private String connectionStringKey;
 
   public String getDatabaseKey() {
     return databaseKey;

--- a/src/test/java/com/sdase/k8s/operator/mongodb/controller/MongoDbControllerTest.java
+++ b/src/test/java/com/sdase/k8s/operator/mongodb/controller/MongoDbControllerTest.java
@@ -114,7 +114,7 @@ class MongoDbControllerTest {
     givenMetadata.setName("the-name");
     var given = new MongoDbCustomResource();
     given.setMetadata(givenMetadata);
-    given.getSpec().getDatabase().setPruneAfterDelete(true);
+    given.setSpec(new MongoDbSpec().setDatabase(new DatabaseSpec().setPruneAfterDelete(true)));
 
     var retryInfoMock = mock(RetryInfo.class);
     when(retryInfoMock.isLastAttempt()).thenReturn(true);
@@ -160,7 +160,7 @@ class MongoDbControllerTest {
     givenMetadata.setName("the-name");
     var given = new MongoDbCustomResource();
     given.setMetadata(givenMetadata);
-    given.getSpec().getDatabase().setPruneAfterDelete(true);
+    given.setSpec(new MongoDbSpec().setDatabase(new DatabaseSpec().setPruneAfterDelete(true)));
 
     var actual = mongoDbController.cleanup(given, new MongoDbCustomResourceContext());
 
@@ -181,7 +181,7 @@ class MongoDbControllerTest {
     givenMetadata.setName("the-name");
     var given = new MongoDbCustomResource();
     given.setMetadata(givenMetadata);
-    given.getSpec().getDatabase().setPruneAfterDelete(true);
+    given.setSpec(new MongoDbSpec().setDatabase(new DatabaseSpec().setPruneAfterDelete(true)));
 
     var retryInfoMock = mock(RetryInfo.class);
     when(retryInfoMock.isLastAttempt()).thenReturn(false);
@@ -203,7 +203,7 @@ class MongoDbControllerTest {
     givenMetadata.setName("the-name" + StringUtils.repeat("-123456789", 3));
     var given = new MongoDbCustomResource();
     given.setMetadata(givenMetadata);
-    given.getSpec().getDatabase().setPruneAfterDelete(true);
+    given.setSpec(new MongoDbSpec().setDatabase(new DatabaseSpec().setPruneAfterDelete(true)));
 
     var givenContext = new MongoDbCustomResourceContext();
 

--- a/src/test/java/com/sdase/k8s/operator/mongodb/controller/V1SecretBuilderTest.java
+++ b/src/test/java/com/sdase/k8s/operator/mongodb/controller/V1SecretBuilderTest.java
@@ -10,6 +10,7 @@ import com.sdase.k8s.operator.mongodb.controller.tasks.util.ConnectionStringUtil
 import com.sdase.k8s.operator.mongodb.controller.tasks.util.NamingUtil;
 import com.sdase.k8s.operator.mongodb.model.v1beta1.DatabaseSpec;
 import com.sdase.k8s.operator.mongodb.model.v1beta1.MongoDbCustomResource;
+import com.sdase.k8s.operator.mongodb.model.v1beta1.MongoDbSpec;
 import com.sdase.k8s.operator.mongodb.model.v1beta1.SecretSpec;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.OwnerReference;
@@ -148,11 +149,12 @@ class V1SecretBuilderTest {
     objectMeta.setUid(TEST_DB_UID);
     var mongoDbCustomResource = new MongoDbCustomResource();
     mongoDbCustomResource.setMetadata(objectMeta);
-    mongoDbCustomResource
-        .getSpec()
-        .setDatabase(
-            new DatabaseSpec()
-                .setConnectionStringOptions("readPreference=secondaryPreferred&retryWrites=false"));
+    mongoDbCustomResource.setSpec(
+        new MongoDbSpec()
+            .setDatabase(
+                new DatabaseSpec()
+                    .setConnectionStringOptions(
+                        "readPreference=secondaryPreferred&retryWrites=false")));
 
     return TaskFactory.customFactory(
             NamingUtil::fromNamespaceAndName,

--- a/test.sh
+++ b/test.sh
@@ -29,7 +29,7 @@ echo "  Found base64 username in 'data.u': ${usernameBase64}"
 echo "${usernameBase64}" | grep "bG9jYWwtdGVzdF9sb2NhbC10ZXN0LWRi" || exit 1
 connectionStringBase64="$(echo "${secret}" | yq .data.c)"
 echo "  Found base64 connection string in 'data.c': ${connectionStringBase64}"
-echo "${connectionStringBase64}" | grep "bW9uZ29kYjovL2xvY2FsLXRlc3RfbG9jYWwtdGVzdC1kYjp2WEJiaXI0eC1wWTRjS3U2X1JBRy1jYSUyQy0zTWR4RldReVIzT0l3bkcwR0Jqel9WTlJoMWZka0NLa3lFZ0Btb25nb2RiLm1vbmdvZGIvbG9jYWwtdGVzdF9sb2NhbC10ZXN0LWRiP3JlYWRQcmVmZXJlbmNlPXNlY29uZGFyeVByZWZlcnJlZCZyZXRyeVdyaXRlcz1mYWxzZQ==" || exit 1
+echo "${connectionStringBase64}" | grep -v "null" || exit 1
 
 echo "👀 then a database user should be created …"
 

--- a/test.sh
+++ b/test.sh
@@ -7,16 +7,29 @@ sleep 15
 echo "  the operator should do the Job …"
 kubectl logs -n mongodb-operator -l serverpod=mongodb-operator
 
-echo "👀 then a secret should be created …"
+echo "👀 then a secret with defaults should be created …"
+
+secret="$(kubectl get secrets -n local-test local-test-defaults-db -o yaml)"
+echo "  Found secret:"
+echo "${secret}"
+usernameBase64="$(echo "${secret}" | yq .data.username)"
+echo "  Found base64 username in 'data.username': ${usernameBase64}"
+echo "${usernameBase64}" | grep -v "null" || exit 1
+connectionStringBase64="$(echo "${secret}" | yq .data.connectionString)"
+echo "  Found base64 connection string in 'data.connectionString': ${connectionStringBase64}"
+echo "${connectionStringBase64}" | grep -v "null" || exit 1
+
+echo "👀 then a secret with custom keys should be created …"
 
 secret="$(kubectl get secrets -n local-test local-test-db -o yaml)"
 echo "  Found secret:"
 echo "${secret}"
 usernameBase64="$(echo "${secret}" | yq .data.u)"
 echo "  Found base64 username in 'data.u': ${usernameBase64}"
+echo "${usernameBase64}" | grep "bG9jYWwtdGVzdF9sb2NhbC10ZXN0LWRi" || exit 1
 connectionStringBase64="$(echo "${secret}" | yq .data.c)"
 echo "  Found base64 connection string in 'data.c': ${connectionStringBase64}"
-echo "${secret}" | grep "bG9jYWwtdGVzdF9sb2NhbC10ZXN0LWRi" || exit 1
+echo "${connectionStringBase64}" | grep "bW9uZ29kYjovL2xvY2FsLXRlc3RfbG9jYWwtdGVzdC1kYjp2WEJiaXI0eC1wWTRjS3U2X1JBRy1jYSUyQy0zTWR4RldReVIzT0l3bkcwR0Jqel9WTlJoMWZka0NLa3lFZ0Btb25nb2RiLm1vbmdvZGIvbG9jYWwtdGVzdF9sb2NhbC10ZXN0LWRiP3JlYWRQcmVmZXJlbmNlPXNlY29uZGFyeVByZWZlcnJlZCZyZXRyeVdyaXRlcz1mYWxzZQ==" || exit 1
 
 echo "👀 then a database user should be created …"
 


### PR DESCRIPTION
It seems like some dependency update in the past changed the behavior of mapping the JSON input to the Java implementation of the resource.
I was not able to reproduce the issue in Java tests. It seems impossible to simulate the exact process Kubernetes is doing at HTTP level for reconcilation in unit tests. It seems like internally a Jackson ObjectMapper is used to read the resources for reconcilation but it's final configuration is unknown. 

However, the extended K8S Integration test should prevent such problem in the future.

We may miss some version pinning in the test (probably for K8S). Making sure, we use well known versions for all tests may be a follow up improvement.

#no-ai