### PR TITLE
Combined Dependency Updates

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -60,7 +60,7 @@ jobs:
           path: artifacts
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3
         with:
           files: artifacts/**/test-results/**/*.xml
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id "idea"
   id "java"
   id 'org.sonarqube' version '7.3.1.8318'
-  id "com.diffplug.spotless" version "8.6.0"
+  id "com.diffplug.spotless" version "8.7.0"
   id "com.google.cloud.tools.jib" version "3.5.3"
   id 'org.cyclonedx.bom' version '3.2.4'
 }


### PR DESCRIPTION
# Combined PRs ➡️📦⬅️

✅ The following pull requests have been successfully combined on this PR:
- Closes #926 fix(deps): bump com.diffplug.spotless from 8.6.0 to 8.7.0
- Closes #924 chore(deps): bump EnricoMi/publish-unit-test-result-action from 2.23.0 to 2.24.0

> This PR was created by the [`github/combine-prs`](https://github.com/github/combine-prs) action