### PR TITLE
Combined Dependency Updates

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -60,7 +60,7 @@ jobs:
           path: artifacts
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3
         with:
           files: artifacts/**/test-results/**/*.xml
 

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ jib {
 project.ext {
   mongoDbDriverVersion = "5.8.0"
   slf4jVersion = "2.0.18"
-  operatorFrameworkVersion = "5.3.4"
+  operatorFrameworkVersion = "5.3.5"
   mockitoVersion = "5.2.0"
   jacksonVersion = "2.22.0"
   logbackContribVersion = "0.1.5"

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id "idea"
   id "java"
   id 'org.sonarqube' version '7.3.1.8318'
-  id "com.diffplug.spotless" version "8.6.0"
+  id "com.diffplug.spotless" version "8.7.0"
   id "com.google.cloud.tools.jib" version "3.5.3"
   id 'org.cyclonedx.bom' version '3.2.4'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ dependencies {
   testImplementation "org.mockito:mockito-inline:${mockitoVersion}"
   testImplementation 'org.awaitility:awaitility:4.3.0'
   testImplementation "io.fabric8:kubernetes-server-mock"
-  testImplementation 'com.squareup.okhttp3:okhttp:5.3.2'
+  testImplementation 'com.squareup.okhttp3:okhttp:5.4.0'
 }
 
 dependencyLocking { lockAllConfigurations() }


### PR DESCRIPTION
# Combined PRs ➡️📦⬅️

✅ The following pull requests have been successfully combined on this PR:
- Closes #926 fix(deps): bump com.diffplug.spotless from 8.6.0 to 8.7.0
- Closes #925 fix(deps): bump operatorFrameworkVersion from 5.3.4 to 5.3.5
- Closes #924 chore(deps): bump EnricoMi/publish-unit-test-result-action from 2.23.0 to 2.24.0
- Closes #920 fix(deps): bump com.squareup.okhttp3:okhttp from 5.3.2 to 5.4.0

⚠️ The following PRs were left out due to merge conflicts:
- #935 chore(deps): bump actions/checkout from 6.0.3 to 7.0.0
- #934 chore(deps): bump actions/setup-java from 5.2.0 to 5.3.0

> This PR was created by the [`github/combine-prs`](https://github.com/github/combine-prs) action